### PR TITLE
Don't crash on anonymous warning

### DIFF
--- a/client/chat.go
+++ b/client/chat.go
@@ -175,13 +175,16 @@ func reactToWarning(
 ) error {
 
 	chatMsg := wire.SNAC_0x01_0x10_OServiceEvilNotification{}
-	if err := wire.Unmarshal(&chatMsg, flapBody); err != nil {
+	// io.EOF can be due to an empty OServiceEvilNotification SNAC
+	// which indicates an anonymous warning, so ignore it
+	if err := wire.Unmarshal(&chatMsg, flapBody); err != nil && err != io.EOF {
 		return err
 	}
 
 	chatCtx, ok := chatContexts[chatMsg.ScreenName]
+	// chatMsg.ScreenName is "" (anonymous), or hasn't sent us an IM yet
 	if !ok {
-		logger.Debug("trying to send warning, but can't find chat context, moving on")
+		logger.Debug("can't find chat context, moving on")
 		return nil
 	}
 


### PR DESCRIPTION
### Summary
If we see an io.EOF error when unmarshalling the OServiceEvilNotification SNAC, it's likely due to it being an OServiceEvilNotificationAnon which does not contain any TLVs such as ScreenName (only NewEvil.)

We can safely catch this error and move on. There will be never be a chat context for a blank ScreenName.

Closes #1

### Testing Done
Before the fix, follow procedure in #1 and you can see the bot crash when it receives an anonymous warning

After the fix, sending an anonymous warning no longer crashes
```
time=2024-06-02T10:23:05.320-07:00 level=DEBUG msg="received SNAC" snac.foodgroup=OService snac.subgroup=OServiceEvilNotification
time=2024-06-02T10:23:05.320-07:00 level=DEBUG msg="can't find chat context, moving on"
```

Sending an identified warning still behaves the same - it responds by sending the user an IM.