### PR TITLE
Fix crash on Talk/DC requests, add profile and message format support

### DIFF
--- a/client/chat.go
+++ b/client/chat.go
@@ -278,6 +278,10 @@ func exchangeMessages(
 	}
 
 	// Get the message text buried in the SNAC payload.
+	if _, hasIMData := msgSNAC.TLVRestBlock.Slice(wire.ICBMTLVAOLIMData); !hasIMData {
+		logger.Debug("received ICBMChannelMsgToClient with no AOLIMData")
+		return nil
+	}
 	msgText, err := msgSNAC.ExtractMessageText()
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -13,4 +13,6 @@ type Config struct {
 	ScreenName      string `envconfig:"SCREEN_NAME" required:"true" val:"smartersmarterchild" description:"The bot's screen name."`
 	WordCountLimit  int    `envconfig:"WORD_COUNT_LIMIT" required:"true" val:"25" description:"The maximum number of words sent to the bot in a single message."`
 	WordLengthLimit int    `envconfig:"WORD_LENGTH_LIMIT" required:"true" val:"15" description:"The maximum length of any word sent to the bot in a single message."`
+	ProfileHTML     string `envconfig:"PROFILE_HTML" required:"true" val:"'<HTML><BODY BGCOLOR=\"#CDFFFE\"><FONT FACE=\"Courier New\" COLOR=\"#000080\" LANG=\"0\">Hello, %n!<BR>Send me an IM to get started!</FONT><BR><BR><HR><FONT SIZE=1>Powered by <A HREF=\"https://github.com/mk6i/smarter-smarter-child\">SmarterSmarterChild</A>.</FONT></BODY></HTML>'" description:"The bot's HTML profile information."`
+	MsgFormat       string `envconfig:"MSG_FORMAT" required:"true" val:"'<HTML><BODY BGCOLOR=\"#CDFFFE\"><FONT FACE=\"Courier New\" COLOR=\"#000080\" LANG=\"0\">@MsgContent@</FONT></BODY></HTML>'" description:"The bot's message response. @MsgContent@ will be replaced with the content of the bot's response."`
 }

--- a/config/ras.service
+++ b/config/ras.service
@@ -15,6 +15,8 @@ Environment="PASSWORD="
 Environment="SCREEN_NAME=smartersmarterchild"
 Environment="WORD_COUNT_LIMIT=25"
 Environment="WORD_LENGTH_LIMIT=15"
+Environment=PROFILE_HTML='<HTML><BODY BGCOLOR="#CDFFFE"><FONT FACE="Courier New" COLOR="#000080" LANG="0">Hello, %n!<BR>Send me an IM to get started!</FONT><BR><BR><HR><FONT SIZE=1>Powered by <A HREF="https://github.com/mk6i/smarter-smarter-child">SmarterSmarterChild</A>.</FONT></BODY></HTML>'
+Environment=MSG_FORMAT='<HTML><BODY BGCOLOR="#CDFFFE"><FONT FACE="Courier New" COLOR="#000080" LANG="0">@MsgContent@</FONT></BODY></HTML>'
 ExecStart=/opt/ssc/smarter_smarter_child
 Restart=on-failure
 

--- a/config/settings.bat
+++ b/config/settings.bat
@@ -30,3 +30,10 @@ set WORD_COUNT_LIMIT=25
 rem The maximum length of any word sent to the bot in a single message.
 set WORD_LENGTH_LIMIT=15
 
+rem The bot's HTML profile information.
+set PROFILE_HTML='<HTML><BODY BGCOLOR="#CDFFFE"><FONT FACE="Courier New" COLOR="#000080" LANG="0">Hello, %n!<BR>Send me an IM to get started!</FONT><BR><BR><HR><FONT SIZE=1>Powered by <A HREF="https://github.com/mk6i/smarter-smarter-child">SmarterSmarterChild</A>.</FONT></BODY></HTML>'
+
+rem The bot's message response. @MsgContent@ will be replaced with the content
+rem of the bot's response.
+set MSG_FORMAT='<HTML><BODY BGCOLOR="#CDFFFE"><FONT FACE="Courier New" COLOR="#000080" LANG="0">@MsgContent@</FONT></BODY></HTML>'
+

--- a/config/settings.env
+++ b/config/settings.env
@@ -30,3 +30,10 @@ export WORD_COUNT_LIMIT=25
 # The maximum length of any word sent to the bot in a single message.
 export WORD_LENGTH_LIMIT=15
 
+# The bot's HTML profile information.
+export PROFILE_HTML='<HTML><BODY BGCOLOR="#CDFFFE"><FONT FACE="Courier New" COLOR="#000080" LANG="0">Hello, %n!<BR>Send me an IM to get started!</FONT><BR><BR><HR><FONT SIZE=1>Powered by <A HREF="https://github.com/mk6i/smarter-smarter-child">SmarterSmarterChild</A>.</FONT></BODY></HTML>'
+
+# The bot's message response. @MsgContent@ will be replaced with the content of
+# the bot's response.
+export MSG_FORMAT='<HTML><BODY BGCOLOR="#CDFFFE"><FONT FACE="Courier New" COLOR="#000080" LANG="0">@MsgContent@</FONT></BODY></HTML>'
+


### PR DESCRIPTION
### Summary

1. Fixes a bug where some requests like Talk or Direct Connection would crash the bot
2. Allow the user to configure a profile and message format for the bot