### PR TITLE
Fix auth with RAS 0.16.1

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -20,7 +20,10 @@ func Authenticate(flapc FlapClient, screenName string, password string) (string,
 
 	challengeRequest := wire.SNAC_0x17_0x06_BUCPChallengeRequest{}
 	challengeRequest.Append(wire.NewTLV(wire.LoginTLVTagsScreenName, screenName))
-	if err := flapc.SendSNAC(wire.SNACFrame{}, challengeRequest); err != nil {
+	if err := flapc.SendSNAC(wire.SNACFrame{
+		FoodGroup: wire.BUCP,
+		SubGroup:  wire.BUCPChallengeRequest,
+	}, challengeRequest); err != nil {
 		return "", "", fmt.Errorf("unable to send SNAC(0x17,0x06): %w", err)
 	}
 
@@ -33,7 +36,10 @@ func Authenticate(flapc FlapClient, screenName string, password string) (string,
 	loginRequest.Append(wire.NewTLV(wire.LoginTLVTagsScreenName, screenName))
 	loginRequest.Append(wire.NewTLV(wire.LoginTLVTagsPasswordHash,
 		wire.StrongMD5PasswordHash(password, challengeResponse.AuthKey)))
-	if err := flapc.SendSNAC(wire.SNACFrame{}, loginRequest); err != nil {
+	if err := flapc.SendSNAC(wire.SNACFrame{
+		FoodGroup: wire.BUCP,
+		SubGroup:  wire.BUCPLoginRequest,
+	}, loginRequest); err != nil {
 		return "", "", fmt.Errorf("unable to send SNAC(0x17,0x02): %w", err)
 	}
 


### PR DESCRIPTION
### Summary
`BUCPChallengeRequest` and `BUCPLoginRequest` now require the FoodGroup and SubGroup to be set.

### Testing
Before this change auth would fail with an EOF error
```
time=2025-04-03T01:13:18.553Z level=DEBUG msg="connected to auth service" host=aim.chivanet.org:5190
time=2025-04-03T01:13:18.706Z level=DEBUG msg="disconnected from auth service" host=""
time=2025-04-03T01:13:18.706Z level=ERROR msg="authentication failed" err="unable to receive SNAC(0x17,0x07): failed to unmarshal: EOF"
```

After this change auth succeeds and the bot can sign on
```
time=2025-04-03T01:39:56.605Z level=INFO msg="connected to BOS server" host=services.chivanet.org:5191
time=2025-04-03T01:39:56.606Z level=DEBUG msg="using OpenAI API chatbot backend"
time=2025-04-03T01:39:56.774Z level=INFO msg="listening for incoming IMs"
```